### PR TITLE
Fix broken finger issue (reset_world)

### DIFF
--- a/smart_grasping_sandbox/src/smart_grasping_sandbox/smart_grasper.py
+++ b/smart_grasping_sandbox/src/smart_grasping_sandbox/smart_grasper.py
@@ -93,8 +93,8 @@ class SmartGrasper(object):
         self.__pause_physics.call()
         
         joint_names = ['shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 
-                       'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint']
-        joint_positions = [1.2, 0.3, -1.5, -0.5, -1.5, 0.0]
+                       'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint', 'H1_F1J1', 'H1_F1J2', 'H1_F1J3', 'H1_F2J1', 'H1_F2J2', 'H1_F2J3', 'H1_F3J1', 'H1_F3J2', 'H1_F3J3']
+        joint_positions = [1.2, 0.3, -1.5, -0.5, -1.5, 0.0, 0.0, -0.3, 0.0, 0.0, -0.3, 0.0, 0.0, -0.3, 0.0]
         
         self.__set_model.call(model_name="smart_grasping_sandbox", 
                               urdf_param_name="robot_description",

--- a/smart_grasping_sandbox/src/smart_grasping_sandbox/smart_grasper.py
+++ b/smart_grasping_sandbox/src/smart_grasping_sandbox/smart_grasper.py
@@ -93,7 +93,8 @@ class SmartGrasper(object):
         self.__pause_physics.call()
         
         joint_names = ['shoulder_pan_joint', 'shoulder_lift_joint', 'elbow_joint', 
-                       'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint', 'H1_F1J1', 'H1_F1J2', 'H1_F1J3', 'H1_F2J1', 'H1_F2J2', 'H1_F2J3', 'H1_F3J1', 'H1_F3J2', 'H1_F3J3']
+                       'wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint', 'H1_F1J1', 'H1_F1J2', 'H1_F1J3', 
+                       'H1_F2J1', 'H1_F2J2', 'H1_F2J3', 'H1_F3J1', 'H1_F3J2', 'H1_F3J3']
         joint_positions = [1.2, 0.3, -1.5, -0.5, -1.5, 0.0, 0.0, -0.3, 0.0, 0.0, -0.3, 0.0, 0.0, -0.3, 0.0]
         
         self.__set_model.call(model_name="smart_grasping_sandbox", 


### PR DESCRIPTION
We had the problem that sometimes after several collisions with the table the fingers of the robot seemed to be broken. Calling the reset_world function did not fix this problem and we had to restart the docker container to reset the finger joints every time this occurred. The reason for this was that in the reset_world function in smart_grasper.py the initial values were only set for the arm joints, not for the finger joints. So I fixed this by adding the initial values for the finger joints.